### PR TITLE
Adjusting Blindness simulation strategy

### DIFF
--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -139,7 +139,8 @@ def advance_state(state: State, debug: bool = False) -> None:
         rel_seq_countdown = state.people.countdown_sequela[name]
         prob = seq_class.timestep_probability(
             delta_time=state._params.delta_time,
-            mf_count=rounded_mf,
+            true_mf_count=total_mf,
+            measured_mf_count=rounded_mf,
             ages=old_ages,
             existing_sequela=state.people.has_sequela,
             has_this_sequela=old_rel_sequela,
@@ -147,10 +148,6 @@ def advance_state(state: State, debug: bool = False) -> None:
         )
 
         new_condition = np.random.random(state.n_people) < prob
-
-        if name == "Blindness":
-            true_mf_condition = total_mf > 0
-            new_condition = np.logical_and(new_condition, true_mf_condition)
 
         if seq_class.end_countdown_become_positive is not None:
             assert seq_class.years_countdown is not None

--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -148,6 +148,10 @@ def advance_state(state: State, debug: bool = False) -> None:
 
         new_condition = np.random.random(state.n_people) < prob
 
+        if name == "Blindness":
+            true_mf_condition = total_mf > 0
+            new_condition = np.logical_and(new_condition, true_mf_condition)
+
         if seq_class.end_countdown_become_positive is not None:
             assert seq_class.years_countdown is not None
 

--- a/epioncho_ibm/state/sequelae.py
+++ b/epioncho_ibm/state/sequelae.py
@@ -139,6 +139,7 @@ class Blindness(Sequela):
         new_arr = np.ones_like(mask, dtype=float)
         valid_items = mask < len(cls.prob_mapper)
         new_arr[valid_items] = cls.prob_mapper[mask[valid_items]]
+        new_arr[~valid_items] = cls.prob_mapper[len(cls.prob_mapper)-1]
         out[for_sample] = new_arr
         return out
 


### PR DESCRIPTION
In the existing code, the application of the blindness probability has two errors. 

1) After the Bernoulli test, the blindness countdown should only be applied to individuals who pass the test, and have "true microfilariae". In the current implementation, the countdown is applied to everyone who passes the Bernoulli test. This is fixed with the addition of lines 151-154 in epioncho_ibm/advance/advance.py

2) If someone has more MF per skin snip than exists in the blindness_prob map, they should not have a 100% chance of blindness, rather just use the very last calculated probability in the map. this is fixed with the addition of line 142 in epioncho_ibm/state/sequelae.py

Below is a graph showing the difference in blindness prevalence after the edits were made.
![no_rebound_varying_mfp](https://github.com/dreamingspires/EPIONCHO-IBM/assets/25516345/3afe6e9b-7343-49ed-9e42-48e87ccd1760)