### PR TITLE
Compliance structure based on overall treatment probability

### DIFF
--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -14,6 +14,21 @@ def advance_state(state: State, debug: bool = False) -> None:
     """Advance the state forward one time step from t to t + dt"""
     _, measured_mf = state.microfilariae_per_skin_snip()
     rounded_mf: Array.Person.Float = np.round(measured_mf)
+    current_treatment_stats = (
+        state._params.treatment.correlation,
+        state._params.treatment.coverage,
+    )
+    last_treatment_stats = (
+        state.people.last_treatment.correlation,
+        state.people.last_treatment.coverage,
+    )
+    if current_treatment_stats != last_treatment_stats:
+        state.people.update_treatment_prob(
+            *current_treatment_stats, state.numpy_bit_generator,
+
+        )
+        state.people.last_treatment.correlation = current_treatment_stats[0]
+        state.people.last_treatment.coverage = current_treatment_stats[1]
     treatment = get_treatment(
         state._params.treatment,
         state._params.delta_time,

--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -185,5 +185,9 @@ def advance_state(state: State, debug: bool = False) -> None:
         state.people.ages >= state._params.humans.max_human_age,
     )
     state.people.process_deaths(
-        people_to_die, state._params.humans.gender_ratio, state.numpy_bit_generator
+        people_to_die,
+        state._params.humans.gender_ratio,
+        state._params.treatment.correlation,
+        state._params.treatment.coverage,
+        state.numpy_bit_generator,
     )

--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -14,21 +14,6 @@ def advance_state(state: State, debug: bool = False) -> None:
     """Advance the state forward one time step from t to t + dt"""
     _, measured_mf = state.microfilariae_per_skin_snip()
     rounded_mf: Array.Person.Float = np.round(measured_mf)
-    current_treatment_stats = (
-        state._params.treatment.correlation,
-        state._params.treatment.coverage,
-    )
-    last_treatment_stats = (
-        state.people.last_treatment.correlation,
-        state.people.last_treatment.coverage,
-    )
-    if current_treatment_stats != last_treatment_stats:
-        state.people.update_treatment_prob(
-            *current_treatment_stats, state.numpy_bit_generator,
-
-        )
-        state.people.last_treatment.correlation = current_treatment_stats[0]
-        state.people.last_treatment.coverage = current_treatment_stats[1]
     treatment = get_treatment(
         state._params.treatment,
         state._params.delta_time,

--- a/epioncho_ibm/advance/treatment.py
+++ b/epioncho_ibm/advance/treatment.py
@@ -7,35 +7,6 @@ from numpy.random import Generator
 from epioncho_ibm.state import Array, HumanParams, TreatmentParams
 
 
-def _calc_coverage(
-    ages: Array.Person.Float,
-    compliance: Array.Person.Bool,
-    measured_coverage: float,
-    age_of_compliance: float,
-    numpy_bit_gen: Generator,
-) -> Array.Person.Bool:
-    """
-    Calculates whether each person in the model is covered by a treatment.
-
-    Args:
-        ages (Array.Person.Float): The ages of the people in the model
-        compliance (Array.Person.Bool): Whether each person in the model is compliant
-        measured_coverage (float): A measured value of coverage assuming all people are compliant.
-        age_of_compliance (float): How old a person must be to be compliant
-        numpy_bit_gen: (Generator): The random number generator for numpy
-
-    Returns:
-        Array.Person.Bool: An array stating if each person in the model is treated
-    """
-    non_compliant_people = (ages < age_of_compliance) | ~compliance
-    compliant_percentage = 1 - np.mean(non_compliant_people)
-    coverage = measured_coverage / compliant_percentage
-    out_coverage = np.repeat(coverage, len(ages))
-    out_coverage[non_compliant_people] = 0
-    rand_nums = numpy_bit_gen.uniform(low=0, high=1, size=len(ages))
-    return rand_nums < out_coverage
-
-
 def _is_during_treatment(
     treatment: TreatmentParams,
     current_time: float,
@@ -93,7 +64,7 @@ def get_treatment(
     current_time: float,
     treatment_times: Optional[Array.Treatments.Float],
     ages: Array.Person.Float,
-    compliance: Optional[Array.Person.Bool],
+    compliance: Optional[Array.Person.Float],
     numpy_bit_gen: Generator,
 ) -> Optional[TreatmentGroup]:
     """
@@ -105,7 +76,7 @@ def get_treatment(
         current_time (float): The current time, t, in the model
         treatment_times (Optional[Array.Treatments.Float]): The times for treatment across the model.
         ages (Array.Person.Float): The ages of the people
-        compliance (Array.Person.Bool): The compliance of the people
+        compliance (Array.Person.Float): The compliance of the people
         numpy_bit_gen: (Generator): The random number generator for numpy
 
     Returns:
@@ -122,15 +93,13 @@ def get_treatment(
             treatment_times,
         )
         if treatment_started:
-            coverage_in = _calc_coverage(
-                ages,
-                compliance,
-                treatment_params.total_population_coverage,
-                treatment_params.min_age_of_treatment,
-                numpy_bit_gen,
-            )
+            rand_nums = numpy_bit_gen.uniform(low=0, high=1, size=len(ages))
+            too_young = ages < treatment_params.min_age_of_treatment
             return TreatmentGroup(
-                treatment_params, coverage_in, treatment_times, treatment_occurred
+                treatment_params=treatment_params
+                coverage_in=(rand_nums < compliance) & ~too_young,
+                treatment_times=treatment_times,
+                treatment_occurred=treatment_occurred,
             )
         else:
             return None

--- a/epioncho_ibm/state/params.py
+++ b/epioncho_ibm/state/params.py
@@ -31,6 +31,8 @@ class TreatmentParams(SpecificTreatmentParams):
     interval_years: float = 1  # treatment interval (years, 0.5 gives biannual)
     start_time: float  # The iteration upon which treatment commences
     stop_time: float  # the iteration upon which treatment stops
+    correlation: float
+    coverage: float
 
 
 class WormParams(BaseModel):

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -187,8 +187,6 @@ class LastTreatment(HDF5Dataclass):
     embryostatic_lambda_max: Array.Person.Float
     embryostatic_phi: Array.Person.Float
     permanent_infertility: Array.Person.Float
-    correlation: float
-    coverage: float
 
     def __eq__(self, other: object) -> bool:
         return (
@@ -310,8 +308,6 @@ class People(HDF5Dataclass):
             embryostatic_lambda_max=last_treatment.copy(),
             embryostatic_phi=last_treatment.copy(),
             permanent_infertility=last_treatment.copy(),
-            correlation=params.treatment.correlation,
-            coverage=params.treatment.coverage,
         )
         # individual exposure to fly bites
         individual_exposure = people_generator.gamma(

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -366,7 +366,7 @@ class People(HDF5Dataclass):
 
     @classmethod
     def draw_compliance_values(corr, cov, size, random_generator):
-        random_generator.beta(
+        return random_generator.beta(
             a=cov * (1. - corr) / corr,
             b=(1 - cov) * (1 - corr) / corr,
             size=size,

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -431,7 +431,7 @@ class People(HDF5Dataclass):
             treatment_correlation,
             treatment_coverage,
             size=total_people_to_die,
-            random_generator=numpy_git_gen,
+            random_generator=numpy_bit_gen,
     )
 
 

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -293,9 +293,11 @@ class People(HDF5Dataclass):
         if params.treatment is None:
             compliance_array = None
         else:
-            compliance_array = (
-                people_generator.uniform(low=0, high=1, size=n_people)
-                > params.treatment.noncompliant_percentage
+            compliance_array = draw_compliance_values(
+                corr=params.treatment.correlation,
+                cov=params.treatment.coverage,
+                size=n_people,
+                random_generator=people_generator,
             )
         last_treatment = np.empty(n_people)
         last_treatment[:] = np.nan
@@ -360,6 +362,14 @@ class People(HDF5Dataclass):
             age_test_OAE=people_generator.uniform(3.0, 15.0, size=n_people),
             has_sequela=has_sequela,
             countdown_sequela=countdown_sequela,
+        )
+
+    @classmethod
+    def draw_compliance_values(corr, cov, size, random_generator):
+        random_generator.beta(
+            a=cov * (1. - corr) / corr,
+            b=(1 - cov) * (1 - corr) / corr,
+            size=size,
         )
 
     def process_deaths(

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -367,7 +367,7 @@ class People(HDF5Dataclass):
     @staticmethod
     def draw_compliance_values(corr, cov, size, random_generator):
         return random_generator.beta(
-            a=cov * (1. - corr) / corr,
+            a=cov * (1 - corr) / corr,
             b=(1 - cov) * (1 - corr) / corr,
             size=size,
         )

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -372,6 +372,30 @@ class People(HDF5Dataclass):
             size=size,
         )
 
+    def update_treatment_prob(self, corr, cov, numpy_bit_gen):
+        """Draw new values for treatment probabilities.
+
+        New treatment probability values are assigned to individuals
+        ensuring that order in probablity value is kept across the
+        population. In other words, individuals who had the highest
+        probablity values before still do after.
+
+        Args:
+            corr (float): Treatment correlation value
+            cov (float): Treatent coverage value
+            numpy_bit_gen (Generator): A random number generator instance
+                 from numpy.
+
+        Returns:
+            Array.Person.Float
+        """
+        new_probs = draw_compliance_values(
+            corr, cov,
+            size=len(self.ages),
+            random_generator=numpy_bit_gen
+        ).sort()
+        self.compliance[np.argsort(self.compliance)] = new_probs
+
     def process_deaths(
         self,
         people_to_die: Array.Person.Bool,

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -187,6 +187,8 @@ class LastTreatment(HDF5Dataclass):
     embryostatic_lambda_max: Array.Person.Float
     embryostatic_phi: Array.Person.Float
     permanent_infertility: Array.Person.Float
+    correlation: float
+    coverage: float
 
     def __eq__(self, other: object) -> bool:
         return (
@@ -308,6 +310,8 @@ class People(HDF5Dataclass):
             embryostatic_lambda_max=last_treatment.copy(),
             embryostatic_phi=last_treatment.copy(),
             permanent_infertility=last_treatment.copy(),
+            correlation=params.treatment.correlation,
+            coverage=params.treatment.coverage,
         )
         # individual exposure to fly bites
         individual_exposure = people_generator.gamma(

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -376,6 +376,8 @@ class People(HDF5Dataclass):
         self,
         people_to_die: Array.Person.Bool,
         gender_ratio: float,
+        treatment_correlation: float,
+        treatment_coverage: float,
         numpy_bit_gen: Generator,
     ):
         if (total_people_to_die := int(np.sum(people_to_die))) > 0:
@@ -401,6 +403,14 @@ class People(HDF5Dataclass):
                 arr[people_to_die] = np.inf
 
         self.delay_arrays.process_deaths(people_to_die)
+        self.compliance[people_to_die] = draw_compliance_values(
+            treatment_correlation,
+            treatment_coverage,
+            size=total_people_to_die,
+            random_generator=numpy_git_gen,
+    )
+
+
 
     def get_people_for_age_group(self, age_start: float, age_end: float) -> "People":
         rel_ages = (self.ages >= age_start) & (self.ages < age_end)

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -230,7 +230,7 @@ def dict_fully_equal(d1: dict[str, np.ndarray], d2: dict[str, np.ndarray]):
 
 
 class People(HDF5Dataclass):
-    compliance: Optional[Array.Person.Bool]
+    compliance: Optional[Array.Person.Float]
     sex_is_male: Array.Person.Bool
     blackfly: BlackflyLarvae
     ages: Array.Person.Float

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -368,7 +368,7 @@ class People(HDF5Dataclass):
             countdown_sequela=countdown_sequela,
         )
 
-    @classmethod
+    @staticmethod
     def draw_compliance_values(corr, cov, size, random_generator):
         return random_generator.beta(
             a=cov * (1. - corr) / corr,
@@ -393,7 +393,7 @@ class People(HDF5Dataclass):
         Returns:
             Array.Person.Float
         """
-        new_probs = draw_compliance_values(
+        new_probs = People.draw_compliance_values(
             corr, cov,
             size=len(self.ages),
             random_generator=numpy_bit_gen

--- a/epioncho_ibm/state/state.py
+++ b/epioncho_ibm/state/state.py
@@ -179,19 +179,18 @@ class State(HDF5Dataclass, BaseState[Params]):
             params (Params): New set of parameters
         """
 
-        def stats_different():
-            current = (
-                self._params.treatment.correlation,
-                self._params.treatment.coverage
-            )
-            new = (params.correlation, params.coverage)
-            return new != current
-
         self.numpy_bit_generator = Generator(SFC64(params.seed))
+
+        stats_different = (
+            params.correlation, params.coverage
+        ) != (
+            self._params.treatment.correlation,
+            self._params.treatment.coverage
+        )
 
         if params.treatment is None:
             self.people.compliance = None
-        elif (self._params.treatment is None) or stats_different():
+        elif (self._params.treatment is None) or stats_different:
             self.people.update_treatment_prob(
                 params.treatment.correlation,
                 params.treatment.coverage,

--- a/epioncho_ibm/state/state.py
+++ b/epioncho_ibm/state/state.py
@@ -66,6 +66,35 @@ def negative_binomial_alt_interface(
     output[n > 0] = temp_output
     return output
 
+
+def recalculate_compliance(
+    is_compliant: Array.Person.Bool,
+    prev_noncompliance_rate: float,
+    new_noncompliance_rate: float,
+    people_generator: Generator,
+):
+    if prev_noncompliance_rate == new_noncompliance_rate:
+        return None
+    elif prev_noncompliance_rate > new_noncompliance_rate:
+        new_draw_rate = new_noncompliance_rate / prev_noncompliance_rate
+        non_comps = len(is_compliant) - sum(is_compliant)
+        new_compliant = people_generator.uniform(low=0, high=1, size=non_comps) < (
+            1 - new_draw_rate
+        )
+        is_compliant[~is_compliant] = new_compliant
+        return None
+    else:
+        new_draw_from_pop = (new_noncompliance_rate - prev_noncompliance_rate) / (
+            1 - prev_noncompliance_rate
+        )
+        comps = sum(is_compliant)
+        new_compliant = people_generator.uniform(low=0, high=1, size=comps) < (
+            1 - new_draw_from_pop
+        )
+        is_compliant[is_compliant] = new_compliant
+        return None
+
+
 @overload
 def _mf_fit_func(x: float, a: float, b: float) -> float:
     ...
@@ -142,6 +171,39 @@ class State(HDF5Dataclass, BaseState[Params]):
 
     def get_params(self) -> Params:
         return immutable_to_mutable(self._params)
+
+    def reset_params(self, params: Params):
+        """Reset the parameters
+
+        Args:
+            params (Params): New set of parameters
+        """
+        self.numpy_bit_generator = Generator(SFC64(params.seed))
+        if params.treatment is not None:
+            if self._params.treatment is not None:
+                if (
+                    self._params.treatment.noncompliant_percentage
+                    != params.treatment.noncompliant_percentage
+                ):
+                    assert self.people.compliance is not None
+                    recalculate_compliance(
+                        self.people.compliance,
+                        self._params.treatment.noncompliant_percentage,
+                        params.treatment.noncompliant_percentage,
+                        self.numpy_bit_generator,
+                    )
+                else:
+                    pass
+            else:
+                self.people.compliance = (
+                    self.numpy_bit_generator.uniform(low=0, high=1, size=self.n_people)
+                    > params.treatment.noncompliant_percentage
+                )
+        else:
+            self.people.compliance = None
+
+        self._params = mutable_to_immutable(params)
+        self._derive_params()
 
     def _derive_params(self) -> None:
         assert self._params

--- a/examples/test_import_from_r.py
+++ b/examples/test_import_from_r.py
@@ -54,7 +54,7 @@ def get_state_from_R(
     # Note: Considered delay indexes
 
     people = People(
-        #! FIXME Since 9c287c5 People.compiance contains treatment
+        #! TODO Since 9c287c5 People.compiance contains treatment
         #! probablity instead of deterministic compliance (a boolean
         #! indicating whether of not an individual will be treated.)
         compliance=compliance,

--- a/examples/test_import_from_r.py
+++ b/examples/test_import_from_r.py
@@ -54,6 +54,9 @@ def get_state_from_R(
     # Note: Considered delay indexes
 
     people = People(
+        #! FIXME Since 9c287c5 People.compiance contains treatment
+        #! probablity instead of deterministic compliance (a boolean
+        #! indicating whether of not an individual will be treated.)
         compliance=compliance,
         sex_is_male=sex_is_male,
         blackfly=blackfly_larvae,


### PR DESCRIPTION
This contribution implements a new structure for compliance to treatment, described in[ this document](https://docs.google.com/document/d/1ZjD-9cfwVKQlTNlnIX_ePLj_Ba_tN6MRqdNtSpnAo4k/edit?usp=sharing). This structure has been implemented in the LF model (C++, link?) and the EPIONCHO.IBM model (R, see https://github.com/mrc-ide/EPIONCHO.IBM/tree/new_compliance).  Note that this contribution does not implement any mechanism for changing values of treatment coverage and correlation, see "Description of the new compliance structure" below.

### Current implementation

The implementation of this model currently maintains a boolean array `compliance` as an attribute of the state.People class. Values in this array, one for each individual, indicate whether or not the individual is effectively treated when selected for treatment. Values in `compliance` are random, drawn from the value of the `SpecificTreatmentParams.noncompliant_percentage` class attribute (`params.py`). Values in the `compliance`array attribute are then combined with coverage parameter to make a decision on whether an individual in actually treated or not, see `advance.treatment._calc_coverage`.

### Description of the new compliance structure

The new compliance structure relies on computing a treatment probability based on both coverage and correlation between treatments. For each individual, the (overall) probability of being treated is given by sampling $\beta(a,b)$ where

```math
a = \mu \times (1. - \rho) / \rho,
b = (1 - \mu) \times (1 - \rho) / \rho,
```

where $\mu$ is the coverage value and $\rho$ the correlation.

Treatment statistics $\mu$ and $\rho$ are allowed to change during a simulation. Probablity of treatment is then (re)computed for each individual, ensuring full rank-correlation i.e. the order of treatment probability is maintained across the population.

### Implementation

I reused the `compliance` array attribute of the `state.People` class. Except that it now contains floats representing the probability of treatment instead of booleans representing compliance. We might want to change the name of this attribute before merging this in to indicate this is really about treatment probability. But I thought keeping the same name will make reviewing these changes easier, initially.

Treatment probability is initialised just the same in `state.People.from_params` based on the expression above

```python
if params.treatment is None:
    compliance_array = None
else:
    compliance_array = draw_compliance_values(
    corr=params.treatment.correlation,
    cov=params.treatment.coverage,
    size=n_people,
    random_generator=people_generator,
)
```

Both `params.treatment.correlation` and `params.treatment.coverage` are new class
attributes of `params.TreatmentParams`.

Both implementation in EPIONCHO.IBM (R) and LF (C++) only compute treatment probability on performing treatment.  This means keeping track of individuals reset since the last treatment event and computing the treatment probability using the right values of coverage and correlation, particularly when one of these values (or both) changed.  In this implementation, the treatment probability is computed as part of the reset process: new individuals are assigned a treatment probability straight away:

```python
# people.People.process_deaths

self.compliance[people_to_die] = draw_compliance_values(
    treatment_correlation,
    treatment_coverage,
    size=total_people_to_die,
    random_generator=numpy_git_gen,
    )
```

Finally, we need keep track of changes in the value of both treatment coverage and correlation.  If they changed since the last step, the values for treatment probabilities are recomputed for each individual in the population using `state.people.People.update_treatment_prob`.  To keep track of treatment statistics, I added two attributes `correlation` and `coverage` to the `state.people.LastTreatment` class.  It think it does the job, but I also think there are better ways. For instance, the re-computation of treatment probabilities could (should?) be carried out automatically whenever the coverage or correlation is changed. But I'm not sure the current implementation allows to change them anyway, as they're implemented as class attributes with hardcoded defaults?

As a matter of fact, this PR does not care for how correlation and coverage values might be changed, it just assumes they could be.




