### PR TITLE
Fix compliance being set to 'None' is 'State.reset_params'

### DIFF
--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -396,8 +396,8 @@ class People(HDF5Dataclass):
         """
         new_probs = People.draw_compliance_values(
             corr, cov, size=len(self.ages), random_generator=numpy_bit_gen
-        ).sort()
-        self.compliance[np.argsort(self.compliance)] = new_probs
+        )
+        self.compliance[np.argsort(self.compliance)] = np.sort(new_probs)
 
     def process_deaths(
         self,


### PR DESCRIPTION
Silly mistake that meant that treatment probabilities were 'reset' to an array of NaN.
This happens whenever parameters are reset ('State.reset_params), for instance when[ switching from one set of parameters to another](https://github.com/dreamingspires/endgame-simulations/blob/1b92348e1fc25afa4ff1c7ec4c7f0851d66e07f3/endgame_simulations/endgame_simulation.py#L335).